### PR TITLE
Add year argument to QuantileDeltaMapping _adjust() to allow rolling …

### DIFF
--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -397,8 +397,7 @@ class QuantileDeltaMapping(EmpiricalQuantileMapping):
                 sim_qts = sim_qts.sel(time=str(year))
                 sim = sim.sel(time=str(year))
             except KeyError as ke:
-                # log this @@
-                print('{} is not in the time series, sending back all years'.format(year))
+                raise KeyError("year ({}) selection must be included in input `sim` time series".format(year)) from ke
         
         sel = {dim: sim_qts[dim] for dim in set(af.dims).intersection(set(sim_qts.dims))}
         sel["quantiles"] = sim_qts


### PR DESCRIPTION
…cdfs in the future sim. Rename sim_q to sim_qts for clarity

Feature: add the ability to provide `QuantileDeltaMapping.adjust()` function a year to select from the time series being bias corrected ("sim"). This gives the ability to use a longer time series cdf to bias correct one year.

For example, to bias correct a future time series with a rolling 20-year cdf centered on the bias correction year:

```
half_window = 10
simy_qdm_list = []
bc_years = np.arange(sim.time.dt.year.values[0] + half_window, sim.time.dt.year.values[-1] - half_window)
for yr in bc_years:
    timeslice = slice(str(yr-half_window),str(yr+half_window))
    simy_qdm_list.append(QDM.adjust(sim.sel(time=timeslice), year=yr))
simy_qdm = xr.concat(simy_qdm_list, dim='time')
```
where `sim` is the future time series and `QDM` is the `QuantileDeltaMapping` object with grouper set to "time.dayofyear". This gives a bias corrected time series where each year is adjusted using a +/- 10yr period CDF around that year.
